### PR TITLE
Markdown docs should use 120-character line lengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,46 @@
 
 ## Project Description
 
-The NFT Pallet is the core of NFT functionality. Like ERC-721 standard in Ethereum ecosystem, this pallet provides the basement for creating collections of unique non-divisible things, also called Non Fungible Tokens (NFTs), minting NFT of a given Collection, and managing their ownership.
+The NFT Pallet is the core of NFT functionality. Like ERC-721 standard in Ethereum ecosystem, this pallet provides the
+basement for creating collections of unique non-divisible things, also called Non Fungible Tokens (NFTs), minting NFT of
+a given Collection, and managing their ownership.
 
-The pallet also enables storing NFT properties. Though (according to ERC-721) NFT properties belong to logic of a concrete application that operates a Collection, so purposefully the NFT Tracking Module does not have any knowledge about properties except their byte size leaving application logic out to be controlled by Smart Contracts.
+The pallet also enables storing NFT properties. Though (according to ERC-721) NFT properties belong to logic of a
+concrete application that operates a Collection, so purposefully the NFT Tracking Module does not have any knowledge
+about properties except their byte size leaving application logic out to be controlled by Smart Contracts.
 
 The NFT Chain also provides:
 
-* Smart Contracts Pallet and example smart contract that interacts with NFT Runtime
-* ERC-1155 Functionality (currently PoC as Re-Fungible tokens, i.e. items that are still unique, but that can be split between multiple users)
-* Variety of economic options for dapp producers to choose from to create freemium games and other ways to attract users. As a step one, we implemented an economic model when a collection sponsor can be set to pay for collection Transfer transactions.
+-   Smart Contracts Pallet and example smart contract that interacts with NFT Runtime
+-   ERC-1155 Functionality (currently PoC as Re-Fungible tokens, i.e. items that are still unique, but that can be split
+    between multiple users)
+-   Variety of economic options for dapp producers to choose from to create freemium games and other ways to attract
+    users. As a step one, we implemented an economic model when a collection sponsor can be set to pay for collection
+    Transfer transactions.
 
 Wider NFT Ecosystem (most of it was developed during Hackusama):
-* [SubstraPunks Game hosted on IPFS](https://github.com/usetech-llc/substrapunks)
-* [NFT Wallet and UI](https://uniqueapps.usetech.com/#/nft)
-* [NFT Asset for Unity Framework](https://github.com/usetech-llc/nft_unity)
+
+-   [SubstraPunks Game hosted on IPFS](https://github.com/usetech-llc/substrapunks)
+-   [NFT Wallet and UI](https://uniqueapps.usetech.com/#/nft)
+-   [NFT Asset for Unity Framework](https://github.com/usetech-llc/nft_unity)
 
 Please see our [walk-thorugh instructions](doc/hackusama_walk_through.md) to try everything out!
 
 ## Hackusama Update
 
 During the Kusama Hackaphon the following changes were made:
-* Enabled Smart Contracts Pallet
-* Enabled integration between Smart Contracts and NFT Pallet (required special edition of RC4 Substrate version)
-* Fixed misc. bugs in NFT Pallet
-* Deployed NFT TestNet. Public node available at wss://unique.usetech.com, custom UI types - see below in this README.
-* New Features:
-  * Re-Fungible Token Mode
-  * Off-Chain Schema to store token image URLs
-  * Alternative economic model
-  * White Lists and Public Mint Permission
-* Use example: [SubstraPunks Game](https://github.com/usetech-llc/substrapunks), fully hosted on IPFS and NFT Testnet Blockchain.
+
+-   Enabled Smart Contracts Pallet
+-   Enabled integration between Smart Contracts and NFT Pallet (required special edition of RC4 Substrate version)
+-   Fixed misc. bugs in NFT Pallet
+-   Deployed NFT TestNet. Public node available at wss://unique.usetech.com, custom UI types - see below in this README.
+-   New Features:
+    -   Re-Fungible Token Mode
+    -   Off-Chain Schema to store token image URLs
+    -   Alternative economic model
+    -   White Lists and Public Mint Permission
+-   Use example: [SubstraPunks Game](https://github.com/usetech-llc/substrapunks), fully hosted on IPFS and NFT Testnet
+    Blockchain.
 
 ## Application Development
 
@@ -41,7 +51,8 @@ If you are building an application that operates NFT tokens, use [this document]
 
 ## Building
 
-Building NFT chain requires special versions of Rust and toolchain. We don't use the most recent versions of everything so that we can keep the builds stable.
+Building NFT chain requires special versions of Rust and toolchain. We don't use the most recent versions of everything
+so that we can keep the builds stable.
 
 1. Install Rust:
 
@@ -59,6 +70,7 @@ rustup install 1.44.0
 ```
 
 4. Make it default (actual toochain version may be different, so do a `rustup toolchain list` first)
+
 ```bash
 rustup toolchain list
 rustup default 1.44.0-x86_64-unknown-linux-gnu
@@ -72,6 +84,7 @@ rustup target add wasm32-unknown-unknown --toolchain nightly-2020-05-01-x86_64-u
 ```
 
 6. Build:
+
 ```bash
 cargo build
 ```
@@ -84,11 +97,17 @@ You can start a development chain with:
 cargo run -- --dev
 ```
 
-Detailed logs may be shown by running the node with the following environment variables set: `RUST_LOG=debug RUST_BACKTRACE=1 cargo run -- --dev`.
+Detailed logs may be shown by running the node with the following environment variables set:
+`RUST_LOG=debug RUST_BACKTRACE=1 cargo run -- --dev`.
 
-If you want to see the multi-node consensus algorithm in action locally, then you can create a local testnet with two validator nodes for Alice and Bob, who are the initial authorities of the genesis chain that have been endowed with testnet units. Give each node a name and expose them so they are listed on the Polkadot [telemetry site](https://telemetry.polkadot.io/#/Local%20Testnet). You'll need two terminal windows open.
+If you want to see the multi-node consensus algorithm in action locally, then you can create a local testnet with two
+validator nodes for Alice and Bob, who are the initial authorities of the genesis chain that have been endowed with
+testnet units. Give each node a name and expose them so they are listed on the Polkadot
+[telemetry site](https://telemetry.polkadot.io/#/Local%20Testnet). You'll need two terminal windows open.
 
-We'll start Alice's substrate node first on default TCP port 30333 with her chain database stored locally at `/tmp/alice`. The bootnode ID of her node is `QmQZ8TjTqeDj3ciwr93EJ95hxfDsb9pEYDizUAbWpigtQN`, which is generated from the `--node-key` value that we specify below:
+We'll start Alice's substrate node first on default TCP port 30333 with her chain database stored locally at
+`/tmp/alice`. The bootnode ID of her node is `QmQZ8TjTqeDj3ciwr93EJ95hxfDsb9pEYDizUAbWpigtQN`, which is generated from
+the `--node-key` value that we specify below:
 
 ```bash
 cargo run -- \
@@ -100,7 +119,9 @@ cargo run -- \
   --validator
 ```
 
-In the second terminal, we'll start Bob's substrate node on a different TCP port of 30334, and with his chain database stored locally at `/tmp/bob`. We'll specify a value for the `--bootnodes` option that will connect his node to Alice's bootnode ID on TCP port 30333:
+In the second terminal, we'll start Bob's substrate node on a different TCP port of 30334, and with his chain database
+stored locally at `/tmp/bob`. We'll specify a value for the `--bootnodes` option that will connect his node to Alice's
+bootnode ID on TCP port 30333:
 
 ```bash
 cargo run -- \
@@ -115,8 +136,8 @@ cargo run -- \
 
 Additional CLI usage options are available and may be shown by running `cargo run -- --help`.
 
-
 ## UI custom types
+
 ```
 {
   "Schedule": {

--- a/doc/application_development.md
+++ b/doc/application_development.md
@@ -40,15 +40,18 @@ addresses can be changed later.
 
 ##### Permissions
 
-Anyone
+-   Anyone
 
 ##### Parameters
 
-customDataSz: Size of NFT properties data.
+-   customDataSz: Size of NFT properties data.
 
 ##### Events
 
-CollectionCreated CollectionID: Globally unique identifier of newly created collection. Owner: Collection owner
+-   CollectionCreated
+    -   CollectionID: Globally unique identifier of newly created collection.
+    -   Mode: Collection mode
+    -   Owner: Collection owner
 
 #### ChangeCollectionOwner
 
@@ -58,11 +61,11 @@ Change the owner of the collection
 
 ##### Permissions
 
-Collection Owner
+-   Collection Owner
 
 ##### Parameters
 
-CollectionId
+-   CollectionId
 
 #### DestroyCollection
 
@@ -73,11 +76,11 @@ real money.
 
 ##### Permissions
 
-Collection Owner
+-   Collection Owner
 
 ##### Parameters
 
-CollectionId
+-   CollectionId
 
 #### CreateItem
 
@@ -87,17 +90,21 @@ This method creates a concrete instance of NFT Collection created with CreateCol
 
 ##### Permissions
 
-Collection Owner Collection Admin
+-   Collection Owner
+-   Collection Admin
 
 ##### Parameters
 
-CollectionID: ID of the collection Properties: Array of bytes that contains NFT properties. Since NFT Module is agnostic
-of properties’ meaning, it is treated purely as an array of bytes Owner: Address, initial owner of the NFT
+-   CollectionID: ID of the collection
+-   Properties: Array of bytes that contains NFT properties. Since NFT Module is agnostic of properties’ meaning, it is
+    treated purely as an array of bytes
+-   Owner: Address, initial owner of the NFT
 
 ##### Events
 
-ItemCreated ItemId: Identifier of newly created NFT, which is unique within the Collection, so the NFT is uniquely
-identified with a pair of values: CollectionId and ItemId.
+-   ItemCreated
+    -   ItemId: Identifier of newly created NFT, which is unique within the Collection, so the NFT is uniquely
+        identified with a pair of values: CollectionId and ItemId.
 
 #### BurnItem
 
@@ -107,15 +114,20 @@ This method destroys a concrete instance of NFT.
 
 ##### Permissions
 
-Collection Owner Collection Admin Current NFT Owner
+-   Collection Owner
+-   Collection Admin
+-   Current NFT Owner
 
 ##### Parameters
 
-CollectionID: ID of the collection ItemID: ID of NFT to burn
+-   CollectionID: ID of the collection
+-   ItemID: ID of NFT to burn
 
 ##### Events
 
-ItemDestroyed CollectionID ItemId: Identifier of burned NFT
+-   ItemDestroyed
+    -   CollectionID
+    -   ItemId: Identifier of burned NFT
 
 #### AddCollectionAdmin
 
@@ -128,11 +140,13 @@ This method adds an admin of the Collection.
 
 ##### Permissions
 
-Collection Owner Collection Admin
+-   Collection Owner
+-   Collection Admin
 
 ##### Parameters
 
-CollectionID: ID of the Collection to add admin for Admin: Address of new admin to add
+-   CollectionID: ID of the Collection to add admin for
+-   Admin: Address of new admin to add
 
 #### RemoveCollectionAdmin
 
@@ -143,11 +157,13 @@ case only Collection Owner will be able to add an Admin.
 
 ##### Permissions
 
-Collection Owner Collection Admin
+-   Collection Owner
+-   Collection Admin
 
 ##### Parameters
 
-CollectionID: ID of the Collection to remove admin for Admin: Address of admin to remove
+-   CollectionID: ID of the Collection to remove admin for
+-   Admin: Address of admin to remove
 
 ### Item Ownership and Transfers
 
@@ -161,11 +177,12 @@ Return the address of the NFT owner.
 
 ##### Permissions
 
-Anyone
+-   Anyone
 
 ##### Parameters
 
-CollectionId ItemId: ID of the NFT
+-   CollectionId
+-   ItemId: ID of the NFT
 
 ##### Returns
 
@@ -180,11 +197,12 @@ to a given address.
 
 ##### Permissions
 
-Anyone
+-   Anyone
 
 ##### Parameters
 
-CollectionId Address to count NFTs for
+-   CollectionId
+-   Address to count NFTs for
 
 ##### Returns
 
@@ -198,11 +216,15 @@ Change ownership of the NFT.
 
 ##### Permissions
 
-Collection Owner Collection Admin Current NFT owner
+-   Collection Owner
+-   Collection Admin
+-   Current NFT owner
 
 ##### Parameters
 
-Recipient: Address of token recipient ClassId: ID of item class ItemId: ID of the item
+-   Recipient: Address of token recipient
+-   ClassId: ID of item class
+-   ItemId: ID of the item
 
 #### TransferFrom
 
@@ -214,11 +236,16 @@ owner.
 
 ##### Permissions
 
-Collection Owner Collection Admin Current NFT owner Address approved by current NFT owner
+-   Collection Owner
+-   Collection Admin
+-   Current NFT owner
+-   Address approved by current NFT owner
 
 ##### Parameters
 
-Recipient: Address of token recipient ClassId: ID of item class ItemId: ID of the item
+-   Recipient: Address of token recipient
+-   ClassId: ID of item class
+-   ItemId: ID of the item
 
 #### Approve
 
@@ -228,12 +255,15 @@ Set, change, or remove approved address to transfer the ownership of the NFT.
 
 ##### Permissions
 
-Collection Owner Collection Admin Current NFT owner
+-   Collection Owner
+-   Collection Admin
+-   Current NFT owner
 
 ##### Parameters
 
-Approved: Address that is approved to transfer this NFT or zero (if needed to remove approval) ClassId: ID of item class
-ItemId: ID of the item
+-   Approved: Address that is approved to transfer this NFT or zero (if needed to remove approval)
+-   ClassId: ID of item class
+-   ItemId: ID of the item
 
 #### GetApproved
 
@@ -243,11 +273,12 @@ Get the approved address for a single NFT.
 
 ##### Permissions
 
-Anyone
+-   Anyone
 
 ##### Parameters
 
-ClassId: ID of item class ItemId: ID of the item
+-   ClassId: ID of item class
+-   ItemId: ID of the item
 
 ##### Returns
 

--- a/doc/application_development.md
+++ b/doc/application_development.md
@@ -2,17 +2,23 @@
 
 ## Architecture
 
-Both centralized and serverless architectures are supported and application creator can decide which one to use depending on how much logic and data they intend to manage off-chain and off-line.
+Both centralized and serverless architectures are supported and application creator can decide which one to use
+depending on how much logic and data they intend to manage off-chain and off-line.
 
 ### Server-based architecture
 
-In server-based architecture the application creator manually creates NFT collections and authorizes server to perform operations on each collection. See NFT palette methods that have admin permission level to understand better what server (or administrators) can do.
+In server-based architecture the application creator manually creates NFT collections and authorizes server to perform
+operations on each collection. See NFT palette methods that have admin permission level to understand better what server
+(or administrators) can do.
 
 ![](server_architecture.png)
 
 ### Serverless architecture
 
-In serverless architecture the application creator does all initialization and token distribution manually. Alternatively, smart contracts may be used in order to implement some distribution mechanics such as token sales or claiming. The dApp has access to all properties of an NFT token, but it does not have any elevated permissions, since it resides on user site. All operations happen on user's behalf signed by user's private key.
+In serverless architecture the application creator does all initialization and token distribution manually.
+Alternatively, smart contracts may be used in order to implement some distribution mechanics such as token sales or
+claiming. The dApp has access to all properties of an NFT token, but it does not have any elevated permissions, since it
+resides on user site. All operations happen on user's behalf signed by user's private key.
 
 ![](serverless_architecture.png)
 
@@ -27,199 +33,222 @@ See in root README
 #### CreateCollection
 
 ##### Description
-This method creates a Collection of NFTs. Each Token may have multiple properties encoded as an array of bytes of certain length. The initial owner and admin of the collection are set to the address that signed the transaction. Both addresses can be changed later.
+
+This method creates a Collection of NFTs. Each Token may have multiple properties encoded as an array of bytes of
+certain length. The initial owner and admin of the collection are set to the address that signed the transaction. Both
+addresses can be changed later.
 
 ##### Permissions
+
 Anyone
 
 ##### Parameters
+
 customDataSz: Size of NFT properties data.
 
 ##### Events
-CollectionCreated
-CollectionID: Globally unique identifier of newly created collection.
-Owner: Collection owner
+
+CollectionCreated CollectionID: Globally unique identifier of newly created collection. Owner: Collection owner
 
 #### ChangeCollectionOwner
 
 ##### Description
+
 Change the owner of the collection
 
 ##### Permissions
+
 Collection Owner
 
 ##### Parameters
+
 CollectionId
 
 #### DestroyCollection
 
 ##### Description
-DANGEROUS: Destroys collection and all NFTs within this collection. Users irrecoverably lose their assets and may lose real money.
+
+DANGEROUS: Destroys collection and all NFTs within this collection. Users irrecoverably lose their assets and may lose
+real money.
 
 ##### Permissions
+
 Collection Owner
 
 ##### Parameters
+
 CollectionId
 
 #### CreateItem
 
 ##### Description
+
 This method creates a concrete instance of NFT Collection created with CreateCollection method.
 
 ##### Permissions
-Collection Owner
-Collection Admin
+
+Collection Owner Collection Admin
 
 ##### Parameters
-CollectionID: ID of the collection
-Properties: Array of bytes that contains NFT properties. Since NFT Module is agnostic of properties’ meaning, it is treated purely as an array of bytes
-Owner: Address, initial owner of the NFT
+
+CollectionID: ID of the collection Properties: Array of bytes that contains NFT properties. Since NFT Module is agnostic
+of properties’ meaning, it is treated purely as an array of bytes Owner: Address, initial owner of the NFT
 
 ##### Events
-ItemCreated
-ItemId: Identifier of newly created NFT, which is unique within the Collection, so the NFT is uniquely identified with a pair of values: CollectionId and ItemId.
+
+ItemCreated ItemId: Identifier of newly created NFT, which is unique within the Collection, so the NFT is uniquely
+identified with a pair of values: CollectionId and ItemId.
 
 #### BurnItem
 
 ##### Description
+
 This method destroys a concrete instance of NFT.
 
 ##### Permissions
-Collection Owner
-Collection Admin
-Current NFT Owner
+
+Collection Owner Collection Admin Current NFT Owner
 
 ##### Parameters
-CollectionID: ID of the collection
-ItemID: ID of NFT to burn
+
+CollectionID: ID of the collection ItemID: ID of NFT to burn
 
 ##### Events
-ItemDestroyed
-CollectionID
-ItemId: Identifier of burned NFT
 
+ItemDestroyed CollectionID ItemId: Identifier of burned NFT
 
 #### AddCollectionAdmin
 
 ##### Description
-NFT Collection can be controlled by multiple admin addresses (some which can also be servers, for example). Admins can issue and burn NFTs, as well as add and remove other admins, but cannot change NFT or Collection ownership.
+
+NFT Collection can be controlled by multiple admin addresses (some which can also be servers, for example). Admins can
+issue and burn NFTs, as well as add and remove other admins, but cannot change NFT or Collection ownership.
 
 This method adds an admin of the Collection.
 
 ##### Permissions
-Collection Owner
-Collection Admin
+
+Collection Owner Collection Admin
 
 ##### Parameters
-CollectionID: ID of the Collection to add admin for
-Admin: Address of new admin to add
+
+CollectionID: ID of the Collection to add admin for Admin: Address of new admin to add
 
 #### RemoveCollectionAdmin
 
 ##### Description
-Remove admin address of the Collection. An admin address can remove itself. List of admins may become empty, in which case only Collection Owner will be able to add an Admin.
+
+Remove admin address of the Collection. An admin address can remove itself. List of admins may become empty, in which
+case only Collection Owner will be able to add an Admin.
 
 ##### Permissions
-Collection Owner
-Collection Admin
+
+Collection Owner Collection Admin
 
 ##### Parameters
-CollectionID: ID of the Collection to remove admin for
-Admin: Address of admin to remove
+
+CollectionID: ID of the Collection to remove admin for Admin: Address of admin to remove
 
 ### Item Ownership and Transfers
+
 This group of methods allows managing NFT ownership.
 
 #### GetOwner
 
 ##### Description
-Return the address of the NFT owner. 
+
+Return the address of the NFT owner.
 
 ##### Permissions
+
 Anyone
 
 ##### Parameters
-CollectionId
-ItemId: ID of the NFT
+
+CollectionId ItemId: ID of the NFT
 
 ##### Returns
+
 Owner address
 
 #### BalanceOf
 
 ##### Description
-This method is included for compatibility with ERC-721. Return the total count of NFTs of a given Collection that belong to a given address. 
+
+This method is included for compatibility with ERC-721. Return the total count of NFTs of a given Collection that belong
+to a given address.
 
 ##### Permissions
+
 Anyone
 
 ##### Parameters
-CollectionId
-Address to count NFTs for
+
+CollectionId Address to count NFTs for
 
 ##### Returns
-Total count of NFTs for Address
 
+Total count of NFTs for Address
 
 #### Transfer
 
 ##### Description
+
 Change ownership of the NFT.
 
 ##### Permissions
-Collection Owner
-Collection Admin
-Current NFT owner
+
+Collection Owner Collection Admin Current NFT owner
 
 ##### Parameters
-Recipient: Address of token recipient
-ClassId: ID of item class
-ItemId: ID of the item
+
+Recipient: Address of token recipient ClassId: ID of item class ItemId: ID of the item
 
 #### TransferFrom
 
 ##### Description
-Change ownership of a NFT on behalf of the owner. See Approve method for additional information. After this method executes, the approval is removed so that the approved address will not be able to transfer this NFT again from this owner.
+
+Change ownership of a NFT on behalf of the owner. See Approve method for additional information. After this method
+executes, the approval is removed so that the approved address will not be able to transfer this NFT again from this
+owner.
 
 ##### Permissions
-Collection Owner
-Collection Admin
-Current NFT owner
-Address approved by current NFT owner
+
+Collection Owner Collection Admin Current NFT owner Address approved by current NFT owner
 
 ##### Parameters
-Recipient: Address of token recipient
-ClassId: ID of item class
-ItemId: ID of the item
 
+Recipient: Address of token recipient ClassId: ID of item class ItemId: ID of the item
 
 #### Approve
 
 ##### Description
+
 Set, change, or remove approved address to transfer the ownership of the NFT.
 
 ##### Permissions
-Collection Owner
-Collection Admin
-Current NFT owner
+
+Collection Owner Collection Admin Current NFT owner
 
 ##### Parameters
-Approved: Address that is approved to transfer this NFT or zero (if needed to remove approval)
-ClassId: ID of item class
+
+Approved: Address that is approved to transfer this NFT or zero (if needed to remove approval) ClassId: ID of item class
 ItemId: ID of the item
 
 #### GetApproved
 
 ##### Description
+
 Get the approved address for a single NFT.
 
 ##### Permissions
+
 Anyone
 
 ##### Parameters
-ClassId: ID of item class
-ItemId: ID of the item
+
+ClassId: ID of item class ItemId: ID of the item
 
 ##### Returns
+
 Approved address

--- a/doc/demo_milestone1-2.md
+++ b/doc/demo_milestone1-2.md
@@ -6,28 +6,41 @@ Milestone 1 and 2 deliverables are marked by tag [release1](https://github.com/u
 
 ### A running chain
 
-**Substrate based blockchain node to host NFT Tracking Module created with substrate-up scripts (currently substrate-up only support Substrate 1.0)**
+**Substrate based blockchain node to host NFT Tracking Module created with substrate-up scripts (currently substrate-up
+only support Substrate 1.0)**
 
-We have created chain based on both versions of substrate: 1 and 2. Nonetheless, the substrate 1 is not being widely used and we decided to obsolete this branch of code. The code still exists in [substrate1](https://github.com/usetech-llc/nft_parachain/tree/substrate1) branch, but this delivery document is based on substrate 2 version.
+We have created chain based on both versions of substrate: 1 and 2. Nonetheless, the substrate 1 is not being widely
+used and we decided to obsolete this branch of code. The code still exists in
+[substrate1](https://github.com/usetech-llc/nft_parachain/tree/substrate1) branch, but this delivery document is based
+on substrate 2 version.
 
 The node can be run using docker container:
+
 ```
 docker-compose up -d
 ```
 
 #### NFT Tracking Module
-Open extrinsics tab of the [standard UI](https://polkadot.js.org/apps/#/extrinsics) and find "nft" in the module list. This proves that NFT module is deployed.
 
-#### Balances Module, Other modules included by default 
-The [same UI](https://polkadot.js.org/apps/#/extrinsics) allows verification that all other modules are also installed as needed.
+Open extrinsics tab of the [standard UI](https://polkadot.js.org/apps/#/extrinsics) and find "nft" in the module list.
+This proves that NFT module is deployed.
+
+#### Balances Module, Other modules included by default
+
+The [same UI](https://polkadot.js.org/apps/#/extrinsics) allows verification that all other modules are also installed
+as needed.
 
 #### Configuration of runtime as needed (e.g. for hot module updates)
 
-The `set_code` method worked out of the box and we did not need to perform any additional customizations to upload an updated WASM version of NFT palette.
+The `set_code` method worked out of the box and we did not need to perform any additional customizations to upload an
+updated WASM version of NFT palette.
 
 ### NFT Tracking Module
 
-Before we continue, we need to do some preparations in the UI: Add NFT Data types so that the UI knows how to decode them. Go to [Settings-Developer Tab](https://polkadot.js.org/apps/#/settings/developer) and add following types to the JSON object in there:
+Before we continue, we need to do some preparations in the UI: Add NFT Data types so that the UI knows how to decode
+them. Go to [Settings-Developer Tab](https://polkadot.js.org/apps/#/settings/developer) and add following types to the
+JSON object in there:
+
 ```
 {
   "NftItemType": {
@@ -50,11 +63,16 @@ Before we continue, we need to do some preparations in the UI: Add NFT Data type
 
 #### CreateCollection
 
-Before running test, open [chain state tab](https://polkadot.js.org/apps/#/chainstate) and read `nft`.`nextCollectionId` state variable, which shows how many collections were created so far. If you just started the chain, this should equal 0. 
+Before running test, open [chain state tab](https://polkadot.js.org/apps/#/chainstate) and read `nft`.`nextCollectionId`
+state variable, which shows how many collections were created so far. If you just started the chain, this should
+equal 0.
 
-Open extrinsics tab of the [standard UI](https://polkadot.js.org/apps/#/extrinsics) and select ALICE account. Select `nft` module and `createCollection` method. Put 1 in `custom_data_size` and run the transaction. After it is finalized, read the `nft`.`nextCollectionId` state variable. It will be equal 1.
+Open extrinsics tab of the [standard UI](https://polkadot.js.org/apps/#/extrinsics) and select ALICE account. Select
+`nft` module and `createCollection` method. Put 1 in `custom_data_size` and run the transaction. After it is finalized,
+read the `nft`.`nextCollectionId` state variable. It will be equal 1.
 
-Also, read the state variable `nft`.`collection` with ID = 1 (Because everything in NFT Palette is numbered from 1, not from 0). You will see something like this:
+Also, read the state variable `nft`.`collection` with ID = 1 (Because everything in NFT Palette is numbered from 1, not
+from 0). You will see something like this:
 
 ```
 nft.collection: CollectionType
@@ -67,7 +85,11 @@ nft.collection: CollectionType
 
 ### ChangeCollectionOwner
 
-Open extrinsics tab of the [standard UI](https://polkadot.js.org/apps/#/extrinsics). Select `nft` module and `changeCollectionOwner` method. First, try to execute it to change owner to BOB for collection 1 from some different account than ALICE - FERDIE to see that it is not possible because ALICE owns collection 1 and FERDIE is not allowed to give it to BOB. Second, select ALICE as transaction signer and run it again. This time the collection owner changes, which will be reflected if you read the state variable `nft`.`collection` with ID = 1:
+Open extrinsics tab of the [standard UI](https://polkadot.js.org/apps/#/extrinsics). Select `nft` module and
+`changeCollectionOwner` method. First, try to execute it to change owner to BOB for collection 1 from some different
+account than ALICE - FERDIE to see that it is not possible because ALICE owns collection 1 and FERDIE is not allowed to
+give it to BOB. Second, select ALICE as transaction signer and run it again. This time the collection owner changes,
+which will be reflected if you read the state variable `nft`.`collection` with ID = 1:
 
 ```
 nft.collection: CollectionType
@@ -84,7 +106,9 @@ Change the ownership back to ALICE to continue with this demo.
 
 **Note: Before destroying collection, you can see Milestone 2 deliverables to avoid creating collection again**
 
-Run `nft`.`destroyCollection` with collection ID = 1, and then read collection from state. The returned fields will have default values, which indicates that collection does not exsit anymore: 
+Run `nft`.`destroyCollection` with collection ID = 1, and then read collection from state. The returned fields will have
+default values, which indicates that collection does not exsit anymore:
+
 ```
 nft.collection: CollectionType
 {
@@ -108,20 +132,29 @@ See above, the unit tests are run before the node starts within the same image.
 
 **using Polkadot UI from https://substrate-ui.parity.io/**
 
-This document, except we are using Substrate v2, so we can use the newer version of the UI: https://polkadot.js.org/apps/#
+This document, except we are using Substrate v2, so we can use the newer version of the UI:
+https://polkadot.js.org/apps/#
 
 ## Milestone 2
+
 ### NFT Tracking Module
+
 **Note:** If you have destroyed collection, create it again using `nft`.`createCollection` method.
 
-**Note 2:** The order of items in this section is different from the original spec to make the acceptance workflow more natural.
+**Note 2:** The order of items in this section is different from the original spec to make the acceptance workflow more
+natural.
 
-If you did not destroy collection while looking at Milestone 1 deliverables, use collection ID 1 in the further examples, otherwise use collection ID = 2.
+If you did not destroy collection while looking at Milestone 1 deliverables, use collection ID 1 in the further
+examples, otherwise use collection ID = 2.
 
 #### CreateItem
-Before creating an NFT item, let's read ALICE balance for your collection, which indicates how many NFT tokens ALICE owns in this collection. Read the chain state `nft`.`balance(<Collection ID>, ALICE)`, and it will be 0.
 
-Execute extrinsic `nft`.`createItem` from ALICE account. Set properties to `0x01`. Now if you read the chain state `nft`.`balance(<Collection ID>, ALICE)`, it will be equal to 1. Also, you can read chain state `nft`.`itemList(<Collection ID>, 1)`, and it will return data for the token 1:
+Before creating an NFT item, let's read ALICE balance for your collection, which indicates how many NFT tokens ALICE
+owns in this collection. Read the chain state `nft`.`balance(<Collection ID>, ALICE)`, and it will be 0.
+
+Execute extrinsic `nft`.`createItem` from ALICE account. Set properties to `0x01`. Now if you read the chain state
+`nft`.`balance(<Collection ID>, ALICE)`, it will be equal to 1. Also, you can read chain state
+`nft`.`itemList(<Collection ID>, 1)`, and it will return data for the token 1:
 
 ```
 nft.itemList: NftItemType
@@ -133,7 +166,10 @@ nft.itemList: NftItemType
 ```
 
 #### GetOwner
-Reading the ownership is done by reading chainstate `nft`.`itemList(<Collection ID>, 1)`. One of the returned fields is Owner:
+
+Reading the ownership is done by reading chainstate `nft`.`itemList(<Collection ID>, 1)`. One of the returned fields is
+Owner:
+
 ```
 nft.itemList: NftItemType
 {
@@ -144,7 +180,9 @@ nft.itemList: NftItemType
 ```
 
 #### Transfer
+
 Execute `nft`.`transfer` from ALICE address to transfer token 1 to BOB and check the ownership again:
+
 ```
 nft.itemList: NftItemType
 {
@@ -159,13 +197,17 @@ Transfer the token 1 back to ALICE to enable further demo actions.
 #### BalanceOf
 
 Read the chain state `nft`.`balance` for ALICE address and see that she owns 1 token:
+
 ```
 nft.balance: u64
 1
 ```
 
 #### AddCollectionAdmin
-Execute `nft`.`AddCollectionAdmin` from ALICE account and let CHARLIE be an admin. Now you can see that CHARLIE can transfer ALICE's token from ALICE's account to EVE and back. Also, you can read admin list from chain state and see that it is not empty:
+
+Execute `nft`.`AddCollectionAdmin` from ALICE account and let CHARLIE be an admin. Now you can see that CHARLIE can
+transfer ALICE's token from ALICE's account to EVE and back. Also, you can read admin list from chain state and see that
+it is not empty:
 
 ```
 nft.adminList: Vec<AccountId>
@@ -175,7 +217,9 @@ nft.adminList: Vec<AccountId>
 ```
 
 #### RemoveCollectionAdmin
-Execute `nft`.`RemoveCollectionAdmin` from ALICE account to remove CHARLIE from admins. Now you can see that CHARLIE cannot transfer ALICE's tokens anymore. If you read the chan state `nft`.`adminList`, the response will be empty:
+
+Execute `nft`.`RemoveCollectionAdmin` from ALICE account to remove CHARLIE from admins. Now you can see that CHARLIE
+cannot transfer ALICE's tokens anymore. If you read the chan state `nft`.`adminList`, the response will be empty:
 
 ```
 nft.adminList: Vec<AccountId>
@@ -183,7 +227,11 @@ nft.adminList: Vec<AccountId>
 ```
 
 #### BurnItem
-Execute `nft`.`burnItem` from ALICE account to burn token 1, and then read the chain state `nft`.`itemList(<Collection ID>, 1)`. This time the chain state returns default values in fields because token does not exist anymore. You can also check ALICE balance in chain state, now it is equal 0 again.
+
+Execute `nft`.`burnItem` from ALICE account to burn token 1, and then read the chain state
+`nft`.`itemList(<Collection ID>, 1)`. This time the chain state returns default values in fields because token does not
+exist anymore. You can also check ALICE balance in chain state, now it is equal 0 again.
+
 ```
 nft.itemList: NftItemType
 {
@@ -194,14 +242,15 @@ nft.itemList: NftItemType
 ```
 
 ### Economic Model Specification
+
 [Economic Model Specification](economic_model.md)
 
 ### Contracts Module Specification
+
 https://docs.google.com/document/d/1gDtYjPR9C1VZChxEA-xAdQWQyEvMg245XrZR_MpE3cg/edit?usp=sharing
 
 ### Bonus goal
 
 **Basic demo - Cryptopunks representation on the Substrate Chain.**
 
-See this repo, it has running and playing instructions:
-https://github.com/usetech-llc/substrapunks
+See this repo, it has running and playing instructions: https://github.com/usetech-llc/substrapunks

--- a/doc/economic_model.md
+++ b/doc/economic_model.md
@@ -2,26 +2,33 @@
 
 ## Economy Goals
 
-One of the goals of this specification is to find means to provide for network infrastructure (incentivisation of validators) and development support for NFT Parachain. Transaction fees will be used as the main source of funds. Fees will be distributed among network participants. The distribution of fees will depend on validator contribution to the network (similarly to Polkadot network) and the chosen fee structure (model).
+One of the goals of this specification is to find means to provide for network infrastructure (incentivisation of
+validators) and development support for NFT Parachain. Transaction fees will be used as the main source of funds. Fees
+will be distributed among network participants. The distribution of fees will depend on validator contribution to the
+network (similarly to Polkadot network) and the chosen fee structure (model).
 
 ## Summary
 
-We are going to offer several fee models for our users. Some models will be implemented immediately, some will wait until there is a demand. 
+We are going to offer several fee models for our users. Some models will be implemented immediately, some will wait
+until there is a demand.
 
-The fee models can be setup by Collection and by Smart Contract address. Every Collection or Smart Contract has a fee model associated with it, which determines how transactions are paid. Network users can choose the fee model that better suits their application. The fee model can be changed later as well.
+The fee models can be setup by Collection and by Smart Contract address. Every Collection or Smart Contract has a fee
+model associated with it, which determines how transactions are paid. Network users can choose the fee model that better
+suits their application. The fee model can be changed later as well.
 
 Initially we offer 4 models for consideration:
 
-* User paid fees (conventional blockchain method)
-* Sponsored (same as above, but paid by sponsor)
-* Prepaid plan
-* Resource purchase
+-   User paid fees (conventional blockchain method)
+-   Sponsored (same as above, but paid by sponsor)
+-   Prepaid plan
+-   Resource purchase
 
 ## Token and Accounts
 
 Network Tokens are tracked via standard Balances module, which is included in NFT Parachain.
 
-User Account matches to user address in the network. Among other properties user Account has Balance, which will be used later on.
+User Account matches to user address in the network. Among other properties user Account has Balance, which will be used
+later on.
 
 ## Settings Economic Model
 
@@ -31,171 +38,234 @@ The dedicated pallet calls allow updating the fee structure for the collection o
 
 #### Description
 
-Set the collection sponsor address. The sponsorship needs to be confirmed by sending a ConfirmSponsorship transaction from that address. Also, the protection measures need to be in place so that sponsor account cannot be depleted by malicious users. White listing is one of the measured. It can be enabled with SetPublicAccessMode method.
+Set the collection sponsor address. The sponsorship needs to be confirmed by sending a ConfirmSponsorship transaction
+from that address. Also, the protection measures need to be in place so that sponsor account cannot be depleted by
+malicious users. White listing is one of the measured. It can be enabled with SetPublicAccessMode method.
 
 ##### List of transactions
+
 Transactions that can be sponsored:
-* Transfer
-* Approve
-* TransferFrom
-* TransferWithData
-* TransferFromWithData
-* BurnItem
+
+-   Transfer
+-   Approve
+-   TransferFrom
+-   TransferWithData
+-   TransferFromWithData
+-   BurnItem
 
 ##### Rate Limiting
 
 This is a design proposal, actual implementation may change.
 
 Features:
-* Token transactions per day: The timestamp of last transaction performed on a token (NFT only) is associated with token ID in a dictionary. When a next transaction is run, the time is checked against this timestamp and, if less than allowed by rate limit, the fee is paid by caller account instead of the sponsor.
-* Address transactions per day: The timestamp of last transaction performed by an address (only if transaction is in the [list of affected transactions](#list-of-transactions)) is associated with caller address in a dictionary. Further, the logic is similar to limiting by token as above. If only one of the limits (by token or by address) indicates that fee should be paid by the user, the fee is paid by the user.
-* A pallet method (SetCollectionRateLimits) will be added to set these parameters and enable rate limiting.
-* One idea to consider is deposits that must be made by an address in order to become white listed (instead of admin review).
+
+-   Token transactions per day: The timestamp of last transaction performed on a token (NFT only) is associated with
+    token ID in a dictionary. When a next transaction is run, the time is checked against this timestamp and, if less
+    than allowed by rate limit, the fee is paid by caller account instead of the sponsor.
+-   Address transactions per day: The timestamp of last transaction performed by an address (only if transaction is in
+    the [list of affected transactions](#list-of-transactions)) is associated with caller address in a dictionary.
+    Further, the logic is similar to limiting by token as above. If only one of the limits (by token or by address)
+    indicates that fee should be paid by the user, the fee is paid by the user.
+-   A pallet method (SetCollectionRateLimits) will be added to set these parameters and enable rate limiting.
+-   One idea to consider is deposits that must be made by an address in order to become white listed (instead of admin
+    review).
 
 #### Permissions
 
-* Collection Owner
+-   Collection Owner
 
 #### Parameters
 
-* CollectionId: ID of the collection
-* Sponsor: Sponsor address
-* Fee Model ID: ID of selected economic model. Currently, only "Sponsored" mode is supported, which will be ID = 1.
+-   CollectionId: ID of the collection
+-   Sponsor: Sponsor address
+-   Fee Model ID: ID of selected economic model. Currently, only "Sponsored" mode is supported, which will be ID = 1.
 
 ### ConfirmSponsorship
+
 #### Description
+
 Confirm sponsorship of a collection. This call is needed to protect sponsor address from malicious collection creators.
 
 #### Permissions
-* Collection Sponsor only
+
+-   Collection Sponsor only
 
 #### Parameters
-* CollectionId: ID of the collection
+
+-   CollectionId: ID of the collection
 
 ### RemoveCollectionSponsor
+
 #### Description
+
 Switch back to pay-per-own-transaction model.
 
 #### Permissions
-* Collection owner
+
+-   Collection owner
 
 #### Parameters
-* collectionId: ID of the collection
+
+-   collectionId: ID of the collection
 
 ### ClaimContract
+
 #### Description
-Claim the contract ownership for the purpose of sponsoring. Once the contract is claimed, only the contract owner can manage the contract sponsorship. Also, the contract may be claimed only once.
+
+Claim the contract ownership for the purpose of sponsoring. Once the contract is claimed, only the contract owner can
+manage the contract sponsorship. Also, the contract may be claimed only once.
 
 #### Permissions
-* Anyone
+
+-   Anyone
 
 #### Parameters
-* ContractAddress: Address of the contract
-* Sponsor: Sponsor address
+
+-   ContractAddress: Address of the contract
+-   Sponsor: Sponsor address
 
 ### SetContractSponsor
+
 #### Description
-Set the contract sponsor address. The sponsorship needs to be confirmed by sending a ConfirmContractSponsorship transaction from that address. The spam protection measures are similar to collection sponsorship.
+
+Set the contract sponsor address. The sponsorship needs to be confirmed by sending a ConfirmContractSponsorship
+transaction from that address. The spam protection measures are similar to collection sponsorship.
 
 #### Permissions
-* Contract Owner
+
+-   Contract Owner
 
 #### Parameters
-* ContractAddress: Address of the contract
-* Sponsor: Sponsor address
-* Fee Model ID: ID of selected economic model. Currently, only "Sponsored" mode is supported, which will be ID = 1.
+
+-   ContractAddress: Address of the contract
+-   Sponsor: Sponsor address
+-   Fee Model ID: ID of selected economic model. Currently, only "Sponsored" mode is supported, which will be ID = 1.
 
 ### ConfirmContractSponsorship
+
 #### Description
+
 Confirm sponsorship of a contract. This call is needed to protect sponsor address from malicious sponsorship requests.
 
 #### Permissions
-* Contract Sponsor only
+
+-   Contract Sponsor only
 
 #### Parameters
-* ContractAddress: Address of the contract
+
+-   ContractAddress: Address of the contract
 
 ### RemoveContractSponsor
+
 #### Description
+
 Switch back to pay-per-own-transaction model.
 
 #### Permissions
-* Contract owner
+
+-   Contract owner
 
 #### Parameters
-* contractAddress: Address of the contract
+
+-   contractAddress: Address of the contract
 
 ### SetPublicAccessMode
-#### Description
-Toggle between normal and white list access for the methods with access for “Anyone”. If White List mode is enabled, AddToWhiteList and RemoveFromWhiteList methods can be called to add to and remove addresses from the white list.
 
-White list mode is the property of collection. If it is turned on, all public operations such as token transfers, for example, which normally have “Anyone” permission, become white listed, i.e. are only available to collection owner, admins, and addresses from the white list. White lists can be helpful for rate limiting of transfers when collection sponsoring is enabled.
+#### Description
+
+Toggle between normal and white list access for the methods with access for “Anyone”. If White List mode is enabled,
+AddToWhiteList and RemoveFromWhiteList methods can be called to add to and remove addresses from the white list.
+
+White list mode is the property of collection. If it is turned on, all public operations such as token transfers, for
+example, which normally have “Anyone” permission, become white listed, i.e. are only available to collection owner,
+admins, and addresses from the white list. White lists can be helpful for rate limiting of transfers when collection
+sponsoring is enabled.
 
 #### Permissions
-* Collection Owner
+
+-   Collection Owner
 
 #### Parameters
-* CollectionID: ID of the Collection to set access mode for
-* Mode
-    * 0 = Normal
-    * 1 = White list
+
+-   CollectionID: ID of the Collection to set access mode for
+-   Mode
+    -   0 = Normal
+    -   1 = White list
 
 ### AddToWhiteList
+
 #### Description
+
 Add an address to white list.
 
 #### Permissions
-* Collection Owner
-* Collection Admin
+
+-   Collection Owner
+-   Collection Admin
 
 #### Parameters
-* CollectionID: ID of the Collection
-* Address
+
+-   CollectionID: ID of the Collection
+-   Address
 
 ### RemoveFromWhiteList
+
 #### Description
+
 Remove an address from white list.
 
 #### Permissions
-* Collection Owner
-* Collection Admin
+
+-   Collection Owner
+-   Collection Admin
 
 #### Parameters
-* CollectionID: ID of the Collection
-* Address
+
+-   CollectionID: ID of the Collection
+-   Address
 
 ### SetCollectionRateLimits
+
 #### Description
+
 Enable or disable rate limits for a collection
 
 #### Permissions
-* Collection Owner
-* Collection Admin
+
+-   Collection Owner
+-   Collection Admin
 
 #### Parameters
-* CollectionID: ID of the Collection
-* TokenInterval: Number of seconds allowed between sponsored token trasnsactions. 0 means there is no limit.
-* AddressInterval: Number of seconds allowed between sponsored address trasnsactions. 0 means there is no limit.
 
+-   CollectionID: ID of the Collection
+-   TokenInterval: Number of seconds allowed between sponsored token trasnsactions. 0 means there is no limit.
+-   AddressInterval: Number of seconds allowed between sponsored address trasnsactions. 0 means there is no limit.
 
 ## User Paid Fees
 
-This is conventional fee model, when every Account pais for the transactions they sign and send. Transaction fee will gradually increase if the network load is higher to prevent denial of service. The same type of transaction (with the same transaction weight) will result in higher fee if previous block's weight gets close to maximum block weight. The ratio for multiplying fees will be determined empirically. The multiplication will take place until the blocks stop overpopulating, but with certain saturation. If blocks underfill, i.e. block weight is under the certain threshold, then the next block will have lower fees. The lowering will continue until blocks stop underpopulating, with some saturation.
+This is conventional fee model, when every Account pais for the transactions they sign and send. Transaction fee will
+gradually increase if the network load is higher to prevent denial of service. The same type of transaction (with the
+same transaction weight) will result in higher fee if previous block's weight gets close to maximum block weight. The
+ratio for multiplying fees will be determined empirically. The multiplication will take place until the blocks stop
+overpopulating, but with certain saturation. If blocks underfill, i.e. block weight is under the certain threshold, then
+the next block will have lower fees. The lowering will continue until blocks stop underpopulating, with some saturation.
 
 Each module call will have weight annotation that will determine the weight calculation for this call:
 
-* CreateCollection: Fixed
-* ChangeCollectionOwner: Fixed
-* DestroyCollection: Linear of number of items (or owner addresses, depending on the collection type) multiplied by Collection Data Size
-* CreateItem: Linear of Collection Data Size
-* BurnItem: Linear of Collection Data Size
-* AddCollectionAdmin: Fixed
-* RemoveCollectionAdmin: Fixed
-* Transfers and approvals: Fixed
-* Transfers with data: Fixed + linear of data size
-* All other: Fixed
+-   CreateCollection: Fixed
+-   ChangeCollectionOwner: Fixed
+-   DestroyCollection: Linear of number of items (or owner addresses, depending on the collection type) multiplied by
+    Collection Data Size
+-   CreateItem: Linear of Collection Data Size
+-   BurnItem: Linear of Collection Data Size
+-   AddCollectionAdmin: Fixed
+-   RemoveCollectionAdmin: Fixed
+-   Transfers and approvals: Fixed
+-   Transfers with data: Fixed + linear of data size
+-   All other: Fixed
 
-This model is default and will be set for each collection until collection owner decides to change it to some other model.
+This model is default and will be set for each collection until collection owner decides to change it to some other
+model.
 
 ### Fee Distribution
 
@@ -203,30 +273,32 @@ The fees will be burned. Incentivization is done through network token inflation
 
 ## Sponsored
 
-The only difference from User Paid Fees model is that collection owner will be paying for their users. The collection owner must have enough balance on his account in order to pay for user transactions.
+The only difference from User Paid Fees model is that collection owner will be paying for their users. The collection
+owner must have enough balance on his account in order to pay for user transactions.
 
 ### Fee Distribution
 
 Same as in User Paid Fees.
-
 
 ## Prepaid Plan
 
-Collection Owner makes regular payments to prepay for some planned network load, i.e. some fixed number of transactions, created items, etc.
-
+Collection Owner makes regular payments to prepay for some planned network load, i.e. some fixed number of transactions,
+created items, etc.
 
 ### Fee Distribution
 
 Same as in User Paid Fees.
 
-
 ## Resource Purchase
 
-Collection Owner purchases some fixed amount of network resource, which can be measured in number of users and their monthly transactions, for example. This is a one time payment. If Collection Owner decides to switch to a different fee model, the resources may be sold back to the system (with some commission).
+Collection Owner purchases some fixed amount of network resource, which can be measured in number of users and their
+monthly transactions, for example. This is a one time payment. If Collection Owner decides to switch to a different fee
+model, the resources may be sold back to the system (with some commission).
 
-Received funds will be converted to DOTs and used in staking (nomination or validation), which will allow to receive the income that will pay for infrastructure and development support.
+Received funds will be converted to DOTs and used in staking (nomination or validation), which will allow to receive the
+income that will pay for infrastructure and development support.
 
 ### Fee Distribution
 
-Fixed percentage of staking income is distributed between validators proportionally to their contribution to the network. The rest is credited to the network owner.
-
+Fixed percentage of staking income is distributed between validators proportionally to their contribution to the
+network. The rest is credited to the network owner.

--- a/doc/hackusama_walk_through.md
+++ b/doc/hackusama_walk_through.md
@@ -8,46 +8,70 @@ This document walks through all Hackusama deliverables made in relation to NFT B
 
 ### Deployed NFT TestNet
 
-The TestNet public node is avaiable at wss://unique.usetech.com. It is easy to verify that it functions with the standard AppsUI:
+The TestNet public node is avaiable at wss://unique.usetech.com. It is easy to verify that it functions with the
+standard AppsUI:
 
 1. Open the [Apps UI](https://polkadot.js.org/apps/#)
 2. Click on the network icon in the top left corner
 3. Scroll down the list and input `wss://unique.usetech.com` under "custom endpoint"
-4. After connection is established, copy these [UI Custom Types](https://github.com/usetech-llc/nft_parachain#ui-custom-types) and paste them in [Developer Settings](https://polkadot.js.org/apps/#/settings/developer). Hit "Save" button.
-5. Now the NFT node is connected with AppsUI. 
-6. Go to [Chain State](https://polkadot.js.org/apps/#/chainstate) and verify that NFT pallet is visible and you can read information from it.
-7. For example, select nft -> collection, and enter collection ID 4 (for SubstraPunks) and click "+" button. You will see the collection properties such as UTF-16 encoded collection name and description, UTF-8 encoded token prefix, the size of custom data, etc.
+4. After connection is established, copy these
+   [UI Custom Types](https://github.com/usetech-llc/nft_parachain#ui-custom-types) and paste them in
+   [Developer Settings](https://polkadot.js.org/apps/#/settings/developer). Hit "Save" button.
+5. Now the NFT node is connected with AppsUI.
+6. Go to [Chain State](https://polkadot.js.org/apps/#/chainstate) and verify that NFT pallet is visible and you can read
+   information from it.
+7. For example, select nft -> collection, and enter collection ID 4 (for SubstraPunks) and click "+" button. You will
+   see the collection properties such as UTF-16 encoded collection name and description, UTF-8 encoded token prefix, the
+   size of custom data, etc.
 
 #### Getting some Unique Tokens
 
-1. Install Polkadot{.js} extension if you don't have it already installed. Here are the links for [Chrome](https://chrome.google.com/webstore/detail/polkadot%7Bjs%7D-extension/mopnmbcafieddcagagdcbnhejhlodfdd) and [Firefox](https://addons.mozilla.org/en-US/firefox/addon/polkadot-js-extension/) extensions.
+1. Install Polkadot{.js} extension if you don't have it already installed. Here are the links for
+   [Chrome](https://chrome.google.com/webstore/detail/polkadot%7Bjs%7D-extension/mopnmbcafieddcagagdcbnhejhlodfdd) and
+   [Firefox](https://addons.mozilla.org/en-US/firefox/addon/polkadot-js-extension/) extensions.
 2. Create an address
-3. Contact us at [Unique Network Telegram channel](https://t.me/joinchat/DPVt1RwN50Uic_Q9lFcg9A) in order to get some Unique token and some Re-Fungible tokens. Faucet is comming soon, we will update this instructions when it goes live.
+3. Contact us at [Unique Network Telegram channel](https://t.me/joinchat/DPVt1RwN50Uic_Q9lFcg9A) in order to get some
+   Unique token and some Re-Fungible tokens. Faucet is comming soon, we will update this instructions when it goes live.
 
 ### Smart Contracts Pallet
 
-1. Open [Contracts](https://polkadot.js.org/apps/#/contracts) tab. It only appears in the UI when Smart Contracts pallet is included in the runtime.
+1. Open [Contracts](https://polkadot.js.org/apps/#/contracts) tab. It only appears in the UI when Smart Contracts pallet
+   is included in the runtime.
 2. Additionally, we can find an existing smart contract. Click on "Add an existing contract" link.
 3. Input this contract address: `5GdNqKMv4Sszq3SRd3TkXNa6a9ct4D3nXvtTWTFR7rTyccVJ`
 4. Input any contract name, for example `Claim Substrapunks`
-5. Download and drag-and-drop this [metadata.json](https://github.com/usetech-llc/substrapunks/releases/download/v1.0.2/metadata.json) file into contract ABI field.
-6. Click Save. The contract appears in the page. If the contract did not exist at that address, the UI would display an error message: "Unable to find deployed contract code at the specified address".
+5. Download and drag-and-drop this
+   [metadata.json](https://github.com/usetech-llc/substrapunks/releases/download/v1.0.2/metadata.json) file into
+   contract ABI field.
+6. Click Save. The contract appears in the page. If the contract did not exist at that address, the UI would display an
+   error message: "Unable to find deployed contract code at the specified address".
 
 ### Integration Between Smart Contracts and NFT Pallet
 
-This was one of the most challenging parts of the Hackusama for us. The pre-RC4 versions of Substrate did not function properly when we tried to use `ext_dispatch_call` to dispatch a runtime call to NFT pallet from Contracts pallet, and RC4 had the `ext_dispatch_call` already removed to "free space" for some friendlier way of interaction between pallets, that was not yet implemented. Thanks to Alexander Theißen who reverted the removal of `ext_dispatch_call` and created a special branch based on RC4 for us!
+This was one of the most challenging parts of the Hackusama for us. The pre-RC4 versions of Substrate did not function
+properly when we tried to use `ext_dispatch_call` to dispatch a runtime call to NFT pallet from Contracts pallet, and
+RC4 had the `ext_dispatch_call` already removed to "free space" for some friendlier way of interaction between pallets,
+that was not yet implemented. Thanks to Alexander Theißen who reverted the removal of `ext_dispatch_call` and created a
+special branch based on RC4 for us!
 
-The smart contract source code exists in this [repository folder](https://github.com/usetech-llc/nft_parachain/tree/master/smart_contract/ink-types-node-runtime), but the best way to test how the interaction between smart contracts and NFT pallet works is to see it in action using the [SubstraPunks Game Example](https://ipfs-gateway.usetech.com/ipns/QmaMtDqE9nhMX9RQLTpaCboqg7bqkb6Gi67iCKMe8NDpCE/) that uses smart contract to claim free characters. The complete demo of this game will come later, so please bare with us and let's put this item demonstration for a bit later.
+The smart contract source code exists in this
+[repository folder](https://github.com/usetech-llc/nft_parachain/tree/master/smart_contract/ink-types-node-runtime), but
+the best way to test how the interaction between smart contracts and NFT pallet works is to see it in action using the
+[SubstraPunks Game Example](https://ipfs-gateway.usetech.com/ipns/QmaMtDqE9nhMX9RQLTpaCboqg7bqkb6Gi67iCKMe8NDpCE/) that
+uses smart contract to claim free characters. The complete demo of this game will come later, so please bare with us and
+let's put this item demonstration for a bit later.
 
 ### Re-Fungibility support
 
-This feature is best demonstrated in action using our NFT wallet. First, you need to have some Unique and Re-Fungible tokens. [This section](#getting-some-unique-tokens) tells how to get them.
+This feature is best demonstrated in action using our NFT wallet. First, you need to have some Unique and Re-Fungible
+tokens. [This section](#getting-some-unique-tokens) tells how to get them.
 
 1. Open the [NFT Wallet](https://uniqueapps.usetech.com/#/nft)
 2. Search for collection called "Artwork". Search can be done either by collection name or collection ID (which is 2).
 3. Click on "+ Add collection" in search results. The collection will appear under "My collections"
 4. Expand the "Artwork" collection and see that you own a token with a partial balance
-5. Transfer the token to some other address: Click "Transfer token" and enter address and the amount. Amount should be entered as decimal fraction. For example "0.01" to transfer 1/100th part of the token. 
+5. Transfer the token to some other address: Click "Transfer token" and enter address and the amount. Amount should be
+   entered as decimal fraction. For example "0.01" to transfer 1/100th part of the token.
 6. Observe that your balance decreased by the amount you entered.
 
 #### The Hard Way
@@ -84,15 +108,19 @@ Also, the Re-Fungible support can be demonstrated using the standard UI features
       fraction: 1,000
     }
   ],
-  Data: 
+  Data:
 }
 ```
 
-The Owner field contains a list of owners with the fractions they own. The fractions are represented as fixed point decimals. The number of decimal points in this fraction is determined by collection properties. For example, in the Artwork collection this property is equal to 4. The owned fraction is then determined as `fraction` divided by 10^DecimalPoints, i.e. 10,000 in this case.
+The Owner field contains a list of owners with the fractions they own. The fractions are represented as fixed point
+decimals. The number of decimal points in this fraction is determined by collection properties. For example, in the
+Artwork collection this property is equal to 4. The owned fraction is then determined as `fraction` divided by
+10^DecimalPoints, i.e. 10,000 in this case.
 
 5. Staying in Chain State, select "nft" - "colection"
 6. Input "2" and click "+"
-7. Observe the following structure returned. It tells that collection is ReFungible and DecimalPoints field is equal to 4.
+7. Observe the following structure returned. It tells that collection is ReFungible and DecimalPoints field is equal
+   to 4.
 
 ```
 {
@@ -111,21 +139,25 @@ The Owner field contains a list of owners with the fractions they own. The fract
 
 ### Off-Chain Schema to store token image URLs
 
-This feature is best demonstrated in action using our NFT wallet. First, you need to have some Unique and Re-Fungible tokens. [This section](#getting-some-unique-tokens) tells how to get them.
+This feature is best demonstrated in action using our NFT wallet. First, you need to have some Unique and Re-Fungible
+tokens. [This section](#getting-some-unique-tokens) tells how to get them.
 
 1. Open the [NFT Wallet](https://uniqueapps.usetech.com/#/nft)
 2. Search for collection called "Artwork". Search can be done either by collection name or collection ID (which is 2).
 3. Expand "Artwork" collection
-4. Click on the image to zoom in. 
+4. Click on the image to zoom in.
 5. Right-click on the image and select "Open Image in New Tab"
 6. Note the image URL:
+
 ```
 https://ipfs-gateway.usetech.com/ipfs/QmUSv64cUmL2m44QYkUFWmH89qykC8VLPFwjhpeAScjejS/image1.jpg
-``` 
+```
+
 7. Open [Chain State](https://uniqueapps.usetech.com/#/chainstate).
 8. Select "nft" - "colection"
 9. Input "2" and click "+"
 10. Scroll down:
+
 ```
   ],
   TokenPrefix: ARTu0000,
@@ -135,23 +167,32 @@ https://ipfs-gateway.usetech.com/ipfs/QmUSv64cUmL2m44QYkUFWmH89qykC8VLPFwjhpeASc
   UnconfirmedSponsor: 5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM
 }
 ```
-11. Observe the field called `OffchainSchema`. This field defines the URL schema that is used to contruct token URLs based on the token ID. In this particular example, the {id} template variable is replaced with token id 1, which results in the proper image URL.
+
+11. Observe the field called `OffchainSchema`. This field defines the URL schema that is used to contruct token URLs
+    based on the token ID. In this particular example, the {id} template variable is replaced with token id 1, which
+    results in the proper image URL.
 
 ### New economic models
 
-This feature is best demonstrated when you own a SubstraPunk character. Please proceed with the demonstration, and then come back after you claim one.
+This feature is best demonstrated when you own a SubstraPunk character. Please proceed with the demonstration, and then
+come back after you claim one.
 
-1. Create a new address in Polkadot{.js} extension. We need an address that has zero balance in Unique tokens. Let's call it "ZERO BALANCE" address.
+1. Create a new address in Polkadot{.js} extension. We need an address that has zero balance in Unique tokens. Let's
+   call it "ZERO BALANCE" address.
 2. Open the [NFT Wallet](https://uniqueapps.usetech.com/#/nft)
 3. Search for collection called "SubstraPunks" (partial search also works, so you can just type "punk" and hit Enter)
 4. Add collection
 5. Expand substrapunks collection and transfer your PNK token to your "ZERO BALANCE" address.
-6. Now select your "ZERO BALANCE" address in the drop-down list and repeat searching and adding the collection for this address.
+6. Now select your "ZERO BALANCE" address in the drop-down list and repeat searching and adding the collection for this
+   address.
 7. Transfer token back to your main address. Observe that despite the zero balance, the transfer is successful.
 
 ### White Lists and Public Mint Permission
 
-We did not complete these features in time by Hackusama deadline, but because they are important for security of the network, we completed them after the deadline anyway. They can be seen in branch [feature/white_list](https://github.com/usetech-llc/nft_parachain/tree/feature/white_list). Here are the permalinks to essential functions:
+We did not complete these features in time by Hackusama deadline, but because they are important for security of the
+network, we completed them after the deadline anyway. They can be seen in branch
+[feature/white_list](https://github.com/usetech-llc/nft_parachain/tree/feature/white_list). Here are the permalinks to
+essential functions:
 
 [white_lists](https://github.com/usetech-llc/nft_parachain/blob/b7c59f0085ed2bc1922e937adf68ef4174a8ba36/pallets/nft/src/lib.rs#L659)
 
@@ -163,17 +204,18 @@ We did not complete these features in time by Hackusama deadline, but because th
 
 All features of the NFT Wallet were already demonstrated previously:
 
-* Enables adding favorite collections
-* Shows tokens owned
-* Allows NFT and Re-Fungible transfers
-* Shows Re-Fungible Balances
-* Shows Token Images
+-   Enables adding favorite collections
+-   Shows tokens owned
+-   Allows NFT and Re-Fungible transfers
+-   Shows Re-Fungible Balances
+-   Shows Token Images
 
 ## Our version of AppsUI
 
 The UI was also mainly demonstrated. We only need to show some configuration that happens behind the scenes:
 
 ### Loads appropriate custom API types
+
 1. Open the [NFT Wallet Developer Settings](https://uniqueapps.usetech.com/#/settings/developer)
 2. Observe that Custom UI types are already in place
 
@@ -191,30 +233,40 @@ In order to see Unity Asset in action, please follow the instructions in this RE
 
 [Demonstration](https://github.com/usetech-llc/nft_unity/blob/master/src/DemoApplication/readme.md)
 
-
 ## SubstraPunks Game
 
 [Project Description](https://github.com/usetech-llc/substrapunks/blob/master/README.md)
 
-First, you will need some Unique balance. [This section](#getting-some-unique-tokens) tells how to get the TestNet currency.
+First, you will need some Unique balance. [This section](#getting-some-unique-tokens) tells how to get the TestNet
+currency.
 
-1. Open this [SubstraPunks Game](https://ipfs-gateway.usetech.com/ipns/QmaMtDqE9nhMX9RQLTpaCboqg7bqkb6Gi67iCKMe8NDpCE/) IPFS link
-2. Find a character you like that still has red background. Red indicates that the character was not yet claimed by anyone.
+1. Open this [SubstraPunks Game](https://ipfs-gateway.usetech.com/ipns/QmaMtDqE9nhMX9RQLTpaCboqg7bqkb6Gi67iCKMe8NDpCE/)
+   IPFS link
+2. Find a character you like that still has red background. Red indicates that the character was not yet claimed by
+   anyone.
 3. Allow access for Polkadot{.js} to this site
 4. Click "Claim" button
 5. Select the account that has some Unique balance
-6. Click "Claim" again, sign transaction, and wait until it mines. 
+6. Click "Claim" again, sign transaction, and wait until it mines.
 
-Let's make a pause here: You were just demonstrated how the integration between smart contracts and NFT Pallet works. This is what we've been previously talking about [here](#integration-between-smart-contracts-and-nft-pallet)
+Let's make a pause here: You were just demonstrated how the integration between smart contracts and NFT Pallet works.
+This is what we've been previously talking about [here](#integration-between-smart-contracts-and-nft-pallet)
 
-The source code of the generic smart contract is located in [smart_contract](https://github.com/usetech-llc/nft_parachain/tree/dev/smart_contract/ink-types-node-runtime) folder. But to demonstrate smart contracts in practice we created additional [Claim Contract](https://github.com/usetech-llc/substrapunks/tree/master/smart_contract) to implement claiming functionality in this game. 
+The source code of the generic smart contract is located in
+[smart_contract](https://github.com/usetech-llc/nft_parachain/tree/dev/smart_contract/ink-types-node-runtime) folder.
+But to demonstrate smart contracts in practice we created additional
+[Claim Contract](https://github.com/usetech-llc/substrapunks/tree/master/smart_contract) to implement claiming
+functionality in this game.
 
-Here is how Claiming works: Claim Contract owns all characters in the game initially. Player sends a transaction calling the method claim:
+Here is how Claiming works: Claim Contract owns all characters in the game initially. Player sends a transaction calling
+the method claim:
+
 ```
 fn claim(&mut self, collection_id: u64, item_id: u64, new_owner: AccountId)
 ```
 
 Inside the method `claim` there is a call made to NFT pallet to transfer the token that is being claimed to the player:
+
 ```
 runtime_calls::transfer(collection_id, item_id, new_owner);
 ```
@@ -222,6 +274,5 @@ runtime_calls::transfer(collection_id, item_id, new_owner);
 7. Follow the link to [NFT Wallet](https://uniqueapps.usetech.com/#/nft)
 8. Search for "SubstraPunks" collection, add it
 9. Expand the collection and find your character in there!
-10. Now you can try transfers and test the [economic model](#new-economic-models), the last thing we put off until a SubstraPunks character is claimed.
-
-
+10. Now you can try transfers and test the [economic model](#new-economic-models), the last thing we put off until a
+    SubstraPunks character is claimed.


### PR DESCRIPTION
Use Prettier to update to 120-character line lengths in Markdown files.
`npx prettier --print-width 120 --prose-wrap=always --write README.md **/*.md`